### PR TITLE
Fix assignment

### DIFF
--- a/compile.ts
+++ b/compile.ts
@@ -468,6 +468,9 @@ class Compiler {
         const v = this.variable(e);
         this.#emit(methods.getSelf, v);
       }
+      if (dest) {
+        this.#emit(methods.setReg, this.variable(e), this.ref(dest, 1, "w"));
+      }
       return this.variable(e);
     } else if (ts.isNumericLiteral(e)) {
       const value = Number(e.text);


### PR DESCRIPTION
The compileExpr function did not handle a non nil dest when the expression is an identifier.

This prevents expression like:
`goto = v`
to emit anything.