### PR TITLE
Fix reference to the check_number function

### DIFF
--- a/compile.ts
+++ b/compile.ts
@@ -805,7 +805,7 @@ class Compiler {
           assertNoDest();
           variable = this.compileResolvedCall(
             expression,
-            "check_number",
+            "checkNumber",
             getNumeric(expression.left),
             [getNumeric(expression.right)]
           );
@@ -817,7 +817,7 @@ class Compiler {
           assertNoDest();
           variable = this.compileResolvedCall(
             expression,
-            "check_number",
+            "checkNumber",
             getNumeric(expression.left),
             [getNumeric(expression.right)]
           );
@@ -904,7 +904,7 @@ class Compiler {
       assertNoDest();
       variable = this.compileResolvedCall(
         expression,
-        "check_number",
+        "checkNumber",
         getNumeric(expression.left),
         [getNumeric(expression.right)]
       );


### PR DESCRIPTION
The check_number function is declared as checkNumber in methods.ts Update the call sites in compile.ts