### PR TITLE
Enable literal boolean in if expressions

### DIFF
--- a/compile.ts
+++ b/compile.ts
@@ -711,13 +711,11 @@ class Compiler {
 
   compileIf(s: ts.IfStatement, dest?: Variable, parentEnd?: string) {
     if (
-      ts.isLiteralExpression(s.expression) &&
       s.expression.kind === ts.SyntaxKind.TrueKeyword
     ) {
       this.compileStatement(s.thenStatement);
       return;
     } else if (
-      ts.isLiteralExpression(s.expression) &&
       s.expression.kind === ts.SyntaxKind.FalseKeyword
     ) {
       if (s.elseStatement) {


### PR DESCRIPTION
Due to https://github.com/microsoft/TypeScript/issues/26075 true and false are not considered literal. This CL change the condition when checking for the expression on the if statement to correctly handle literable booleans