### PR TITLE
Fix dead code deletion

### DIFF
--- a/assembler.ts
+++ b/assembler.ts
@@ -468,7 +468,7 @@ class Assembler {
       const accessibleLabels = new Set<string>();
       for (let instr of code) {
         if (typeof instr.next == "string") {
-          accessibleLabels.add(instr.next);
+          accessibleLabels.add(labelInfo.resolve(instr.next));
         }
         for (let arg of instr.args) {
           if (arg.startsWith(":")) {

--- a/tests/__snapshots__/assembler.test.ts.snap
+++ b/tests/__snapshots__/assembler.test.ts.snap
@@ -58,3 +58,16 @@ exports[`label.asm 1`] = `
   "parameters": [],
 }
 `;
+
+exports[`dead_code_deletion.asm 1`] = `
+{
+  "0": {
+    "op": "set_reg",
+  },
+  "1": {
+    "next": 1,
+    "op": "set_reg",
+  },
+  "parameters": [],
+}
+`;

--- a/tests/dead_code_deletion.asm
+++ b/tests/dead_code_deletion.asm
@@ -1,0 +1,11 @@
+  jump :label3
+label1:
+  nop
+  jump :label2
+label2:
+  set_reg
+label3:
+  set_reg
+  jump :label1
+
+


### PR DESCRIPTION
Accessible labels detection must always resolve the labels.