### PR TITLE
Fix argument of methods with thisArg

### DIFF
--- a/compile.ts
+++ b/compile.ts
@@ -776,9 +776,11 @@ class Compiler {
       info.special == "txt" && rawArgs[0] && ts.isStringLiteral(rawArgs[0]);
     const txtArg = hasTxt && (rawArgs.shift() as ts.StringLiteral).text;
 
-    info.in?.forEach((v, i) => {
-      args[v] = rawArgs[i] ? this.compileExpr(rawArgs[i]) : nilReg;
-    });
+    info.in
+      ?.filter(v => info.thisArg !== v)
+      .forEach((v, i) => {
+        args[v] = rawArgs[i] ? this.compileExpr(rawArgs[i]) : nilReg;
+      });
     if (info.thisArg != null) {
       if (
         info.autoSelf &&

--- a/tests/__snapshots__/compile.test.ts.snap
+++ b/tests/__snapshots__/compile.test.ts.snap
@@ -136,6 +136,21 @@ l11:
   .ret	"
 `;
 
+exports[`this_arg_param.ts 1`] = `
+"test:
+  .name	"test"
+  .pname	p1, a
+  select_nearest	:l1, :l2, p1, signal
+l1:
+  notify	$txt="a"
+  jump	:l0
+l2:
+  notify	$txt="b"
+  jump	:l0
+l0:
+  .ret	"
+`;
+
 exports[`variable_blocks.ts 1`] = `
 "foo:
   .name	"foo"

--- a/tests/this_arg_param.ts
+++ b/tests/this_arg_param.ts
@@ -1,0 +1,8 @@
+export function test(a) {
+    let closest = a.nearerThan(signal);
+    if(closest) {
+        notify("a");
+    } else {
+        notify("b");
+    }
+}


### PR DESCRIPTION
Previously the following code:

```typescript
    let closest = v.nearerThan(signal);
    if(closest) {
        notify("a");
    } else {
        notify("b");
    }
```

Would generate

```
select_nearest	:l1, :l2, p1
```