### PR TITLE
Return control flow separately from branch instructions

### DIFF
--- a/scripts/overrides.json
+++ b/scripts/overrides.json
@@ -57,6 +57,11 @@
           "B": false
         },
         "outArgs": []
+      },
+      {
+        "js": "selectNearest",
+        "type": "function",
+        "firstArgControlFlow": true
       }
     ],
     "type": "operator"

--- a/tests/__snapshots__/compile.test.ts.snap
+++ b/tests/__snapshots__/compile.test.ts.snap
@@ -134,6 +134,25 @@ exports[`call_with_computation.ts 1`] = `
   .ret	"
 `;
 
+exports[`first_arg_control_flow.ts 1`] = `
+"foo:
+  .name	"foo"
+  .pname	p1, "v"
+  select_nearest	:l1, :l2, p1, signal, A
+  jump	:l3
+l1:
+  notify	A, $txt="A is closest"
+  jump	:l0
+l2:
+  notify	A, $txt="B is closest"
+  jump	:l0
+l3:
+  notify	$txt="Default branch"
+  jump	:l0
+l0:
+  .ret	"
+`;
+
 exports[`if_unit_type.ts 1`] = `
 "test:
   .name	"test"

--- a/tests/first_arg_control_flow.ts
+++ b/tests/first_arg_control_flow.ts
@@ -1,0 +1,14 @@
+export function foo(v: Value) {
+  let [branch, nearest] = selectNearest(v, signal);
+  switch (branch) {
+    case "A":
+      notify("A is closest", nearest);
+      break;
+    case "B":
+      notify("B is closest", nearest);
+      break;
+    default:
+      notify("Default branch");
+      break;
+  }
+}


### PR DESCRIPTION
This gives access to the value even when branching multiple times, such as selectNearest which has 3 branches and a return value