### PR TITLE
Fix switch statements without a default case

### DIFF
--- a/compile.ts
+++ b/compile.ts
@@ -859,6 +859,7 @@ class Compiler {
               s
             );
           }
+          let hasDefault = false;
           for (const clause of s.caseBlock.clauses) {
             const clauseLabel = this.#label();
             this.#emitLabel(clauseLabel);
@@ -866,13 +867,21 @@ class Compiler {
               const key = this.#parseNormalSwitchExpression(clause.expression);
               this.#rewriteLabel(variable.exec.get(key)!, clauseLabel);
             } else {
+              hasDefault = true;
               variable.exec.forEach((ref) => {
                 this.#rewriteLabel(ref, clauseLabel, true);
               });
             }
             clause.statements.forEach(this.compileStatement, this);
           }
+
+          if(!hasDefault) {
+            variable.exec.forEach((ref) => {
+              this.#rewriteLabel(ref, theEnd, true);
+            });
+          }
         }
+
         this.#emitLabel(theEnd);
       }
     );

--- a/tests/__snapshots__/compile.test.ts.snap
+++ b/tests/__snapshots__/compile.test.ts.snap
@@ -115,6 +115,19 @@ l0:
   .ret	"
 `;
 
+exports[`switch_no_default.ts 1`] = `
+"foo:
+  .name	"foo"
+  .pname	p1, v
+  value_type	p1, :l0, :l0, :l0, :l0, :l0, :l0
+  jump	:l1
+l1:
+  notify	$txt="No Match"
+  jump	:l0
+l0:
+  .ret	"
+`;
+
 exports[`test1.ts 1`] = `
 "foo:
   .name	"foo"

--- a/tests/switch_no_default.ts
+++ b/tests/switch_no_default.ts
@@ -1,0 +1,7 @@
+export function foo(v: Value) {
+    switch(v.type) {
+        case "No Match":
+            notify("No Match");
+            break;
+    }
+}


### PR DESCRIPTION
Previously the default case would jump into the first case, if the default statement was omitted.