### PR TITLE
Fix missing number Value types in geninstr

### DIFF
--- a/scripts/geninstr.ts
+++ b/scripts/geninstr.ts
@@ -422,7 +422,10 @@ for (const op of Object.values(methods)) {
 );
 
 const dtsContents = `
-type Value = number & {
+type Value = number & BaseValue;
+interface Number extends BaseValue {}
+
+interface BaseValue {
 ${dtsProps.join("\n")}
 
 ${dtsMethods.join("\n")}


### PR DESCRIPTION
When https://github.com/ribrdb/desynced-tools/pull/44/files was updated the change to the Value definition was accidentally lost in geninstr.ts

This was still included in behavior.d.ts, but those changes are lost whenever the file is regenerated.