### PR TITLE
Remove warnings when compiling in browser + speedup 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ website/monaco-editor-0.45.0
 # Generated files
 behavior.d.ts
 behavior_dts.ts
+lib_dts.ts
 methods.ts
 decompile/dsinstr.ts
 

--- a/compile.ts
+++ b/compile.ts
@@ -6,6 +6,8 @@ import {Code} from "./ir/code";
 import {Arg, Instruction, Label, LiteralValue, RegRef, Stop, StringLiteral, VariableRef,} from "./ir/instruction";
 import {generateAsm} from "./decompile/disasm";
 import {getDataById} from "./data";
+import {CompilerOptions} from "./compiler_options"
+export {CompilerOptions}
 
 // Some arbitrary things to use for dynamic jump labels
 const dynamicLabels = [
@@ -1536,14 +1538,6 @@ function resolveVariables(inst:Instruction) {
 }
 
 const nilReg = new RegRef(0);
-
-export const CompilerOptions: ts.CompilerOptions = {
-  lib: ["lib.es2023.d.ts"],
-  target: ts.ScriptTarget.ES2022,
-  moduleResolution: ts.ModuleResolutionKind.NodeNext,
-  module: ts.ModuleKind.NodeNext,
-  noEmit: true,
-};
 
 export function compileProgram(program: ts.Program): string {
   // TODO: ended up not using the typechecker. Should probably just parse

--- a/compiler_bundle.ts
+++ b/compiler_bundle.ts
@@ -3,18 +3,17 @@ import * as tsvfs from "@typescript/vfs";
 import * as ts from "typescript";
 import { CompilerOptions, compileProgram } from "./compile.js";
 import { behavior_dts } from "./behavior_dts.js";
+import { lib_dts } from "./lib_dts.js";
 export { CompilerOptions, compileProgram };
 
-export async function makeProgram(
+export function makeProgram(
   tsCode: string,
   compilerOptions = CompilerOptions
 ) {
-  const fsMap = await tsvfs.createDefaultMapFromCDN(
-    compilerOptions,
-    ts.version,
-    true,
-    ts
-  );
+  const fsMap = new Map<string, string>();
+  for(const lib in lib_dts) {
+    fsMap.set(lib, lib_dts[lib]);
+  }
   fsMap.set("index.ts", tsCode);
   fsMap.set("behavior.d.ts", behavior_dts);
 

--- a/compiler_options.ts
+++ b/compiler_options.ts
@@ -1,0 +1,10 @@
+import * as ts from "typescript";
+
+export const CompilerOptions: ts.CompilerOptions = {
+    lib: ["lib.es2023.d.ts"],
+    types: [],
+    target: ts.ScriptTarget.ES2022,
+    moduleResolution: ts.ModuleResolutionKind.NodeNext,
+    module: ts.ModuleKind.NodeNext,
+    noEmit: true,
+};

--- a/scripts/geninstr.ts
+++ b/scripts/geninstr.ts
@@ -10,6 +10,9 @@
 import * as fs from "fs";
 import { gameData, GameData } from "../data";
 import overrides from "./overrides.json";
+import {CompilerOptions} from "../compiler_options";
+import * as ts from "typescript";
+import path from "path";
 
 const dtsProps: string[] = [];
 const dtsMethods: string[] = [];
@@ -489,6 +492,16 @@ declare function value(id: Extra, num?: number): Value;
 
 fs.writeFileSync("behavior.d.ts", dtsContents);
 fs.writeFileSync("behavior_dts.ts", `export const behavior_dts = ${JSON.stringify(dtsContents)}`);
+
+const tsLibFiles = (() => {
+  const program = ts.createProgram(CompilerOptions.lib!, CompilerOptions);
+  const result = {};
+  for (const sourceFile of program.getSourceFiles()) {
+    result['/' + path.basename(sourceFile.fileName)] = sourceFile.text;
+  }
+  return result;
+})();
+fs.writeFileSync("lib_dts.ts", `export const lib_dts = ${JSON.stringify(tsLibFiles, null, 2)}`);
 
 fs.writeFileSync(
   "decompile/dsinstr.ts",

--- a/website/index.html
+++ b/website/index.html
@@ -42,6 +42,8 @@
     monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
       target: monaco.languages.typescript.ScriptTarget.ESNext,
       lib: ["lib.es2023.d.ts"],
+      moduleResolution: monaco.languages.typescript.ModuleResolutionKind.NodeJs,
+      module: monaco.languages.typescript.ModuleKind.ESNext
     });
     const behaviorFilename = "ts:behavior.d.ts";
     monaco.languages.typescript.typescriptDefaults.addExtraLib(
@@ -184,10 +186,10 @@ label6:
         asm = code;
       } else {
         const compiler = await compilerPromise;
-        const prog = await compiler.makeProgram(code);
-        asm = await compiler.compileProgram(prog);
+        const prog = compiler.makeProgram(code);
+        asm = compiler.compileProgram(prog);
       }
-      const obj = await ds.assemble(asm);
+      const obj = ds.assemble(asm);
       const type = obj.frame ? "B" : "C";
       const text = ds.ObjectToDesyncedString(obj, type);
       let copied = false;


### PR DESCRIPTION
* Remove warnings when compiling in browser + speedup 
  Previously the typescript libraries were provided via tsvfs.createDefaultMapFromCDN which includes additional definition files that we do not use, including dom.d.ts
  
  This produces irrelevant warnings when compiling the typescript source files in the browser. We now generate a lib_dts.ts, similar to behavior_dts.ts, which contains the relevant library files that are used during compilation.
  
  An added benefit is that compilation feels faster than before.