### PR TITLE
Don't clear editor contents when writing to clipboard fails

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -190,18 +190,11 @@ label6:
       const obj = await ds.assemble(asm);
       const type = obj.frame ? "B" : "C";
       const text = ds.ObjectToDesyncedString(obj, type);
-      let copied = false;
-      if (navigator.userActivation.isActive) {
-        try {
+      try {
         await navigator.clipboard.writeText(text);
-        copied = true;
         alert("Copied to clipboard");
-        } catch {}
-      } 
-      if (!copied) {
-        txtModel.setValue(text);
-        editor.setModel(txtModel);
-        editor.setSelection(txtModel.getFullModelRange());
+      } catch {
+        prompt("Behavior string:", text);
       }
     });
   });


### PR DESCRIPTION
Instead present behavior string via a prompt dialogue where the user can copy it