### PR TITLE
Fix compilation of loops with multiple arguments

### DIFF
--- a/tests/__snapshots__/compile.test.ts.snap
+++ b/tests/__snapshots__/compile.test.ts.snap
@@ -103,6 +103,29 @@ label5:
   .ret	"
 `;
 
+exports[`loops.ts 1`] = `
+"loops:
+  .name	"loops"
+  for_signal_match	metalore, C, D, :l1
+  jump	:l0
+l0:
+  notify	C
+  notify	D
+  .ret	
+l1:
+  for_signal_match	metalore, A, B, :l3
+  jump	:l2
+l2:
+  set_reg	1, C
+  notify	C
+  last	
+  .ret	
+l3:
+  notify	A
+  notify	B
+  .ret	"
+`;
+
 exports[`nested_sub.ts 1`] = `
 "foo:
   .name	"foo"

--- a/tests/loops.ts
+++ b/tests/loops.ts
@@ -1,0 +1,17 @@
+export function loops() {
+    for (let [a, b] of matchingSignals(value("metalore"))) {
+        notify(a);
+        notify(b);
+    }
+
+    let c: Value;
+    let d: Value;
+    for ([c, d] of matchingSignals(value("metalore"))) {
+        let x: Value = 1;
+        notify(x);
+        break;
+    }
+
+    notify(c);
+    notify(d);
+}


### PR DESCRIPTION
This allows the following syntax:

```typescript
let a: Value;
let b: Value;
for([a, b] of matchingSignals(value("metalore"))) {
  break;
}

notify(a);
```

Making the variable accessible outside of the loop scope